### PR TITLE
overseer: Write some tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.11', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m unittest discover -s tests

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+'''Unit tests for the pure/logic functions in todo.py.
+
+Run with: python3 -m unittest discover -s tests
+
+todo.py reads ~/.todo/config.cfg and creates data files at import time, so we
+point HOME at a throwaway dir with a pre-seeded config BEFORE importing it.
+'''
+
+import os
+import sys
+import tempfile
+import configparser
+import unittest
+
+# --- make todo.py importable without triggering the interactive first-run setup
+_TMP = tempfile.mkdtemp(prefix='todo_test_')
+os.environ['HOME'] = _TMP
+os.makedirs(os.path.join(_TMP, '.todo'), exist_ok=True)
+_cfg = configparser.ConfigParser()
+_cfg['general'] = {'dir': _TMP, 'name': 'Test'}
+with open(os.path.join(_TMP, '.todo', 'config.cfg'), 'w') as _f:
+    _cfg.write(_f)
+
+sys.argv = ['todo.py']  # empty command line; execution is guarded by __main__ anyway
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import todo  # noqa: E402
+
+
+class TestDeltatime(unittest.TestCase):
+    def test_empty_string(self):
+        self.assertEqual(todo._deltatime(''), '0:00:00')
+
+    def test_seconds(self):
+        self.assertEqual(todo._deltatime('90'), '0:01:30')
+
+    def test_hours(self):
+        self.assertEqual(todo._deltatime('3661'), '1:01:01')
+
+    def test_strips_fraction(self):
+        self.assertEqual(todo._deltatime('1.5'), '0:00:01')
+
+
+class TestCsvlist(unittest.TestCase):
+    def test_multiple(self):
+        self.assertEqual(todo._csvlist("['a', 'b']"), ['a', 'b'])
+
+    def test_single(self):
+        self.assertEqual(todo._csvlist("['solo']"), ['solo'])
+
+    def test_no_space_separator(self):
+        self.assertEqual(todo._csvlist("['a','b']"), ['a', 'b'])
+
+    def test_non_list_returns_none(self):
+        self.assertIsNone(todo._csvlist(''))
+        self.assertIsNone(todo._csvlist('not a list'))
+
+
+class TestCsvNum(unittest.TestCase):
+    def test_int(self):
+        self.assertEqual(todo._csvint(' 5 '), 5)
+
+    def test_int_empty(self):
+        self.assertEqual(todo._csvint(''), 0)
+
+    def test_int_garbage(self):
+        self.assertEqual(todo._csvint('abc'), 0)
+
+    def test_float(self):
+        self.assertEqual(todo._csvfloat('1.5'), 1.5)
+
+    def test_float_empty(self):
+        self.assertEqual(todo._csvfloat('   '), 0)
+
+
+class TestIsImportant(unittest.TestCase):
+    def test_falsey(self):
+        self.assertFalse(todo._isImportant(''))
+        self.assertFalse(todo._isImportant('0'))
+        self.assertFalse(todo._isImportant(None))
+
+    def test_truthy(self):
+        self.assertTrue(todo._isImportant('1'))
+        self.assertTrue(todo._isImportant('42'))
+
+
+class TestIsDue(unittest.TestCase):
+    def test_falsey(self):
+        self.assertFalse(todo._isDue(''))
+        self.assertFalse(todo._isDue('0'))
+        self.assertFalse(todo._isDue('later'))
+        self.assertFalse(todo._isDue(None))
+
+    def test_truthy(self):
+        self.assertTrue(todo._isDue('1'))
+        self.assertTrue(todo._isDue('soon'))
+
+
+class TestParseQuery(unittest.TestCase):
+    def test_tasklist_and_tag(self):
+        q = todo.parseQuery('@work +urgent')
+        self.assertEqual(q['tasklists'], ['work'])
+        self.assertEqual(q['tags'], ['urgent'])
+
+    def test_important_and_due(self):
+        q = todo.parseQuery('important soon')
+        self.assertTrue(q['important'])
+        self.assertTrue(q['due'])
+
+    def test_unimportant_and_later(self):
+        q = todo.parseQuery('unimportant later')
+        self.assertFalse(q['important'])
+        self.assertFalse(q['due'])
+
+    def test_empty(self):
+        self.assertEqual(todo.parseQuery(''), {})
+
+
+class TestQuery(unittest.TestCase):
+    def _rows(self):
+        return [
+            {'tasklist': 'work', 'tags': "['urgent']", 'important': '1', 'due': '1'},
+            {'tasklist': 'home', 'tags': "['chore']", 'important': '0', 'due': '0'},
+            {'tasklist': 'work', 'tags': "['chore']", 'important': '0', 'due': 'soon'},
+        ]
+
+    def test_filter_by_tasklist(self):
+        res = todo.query({'tasklists': ['work']}, self._rows())
+        self.assertEqual(len(res), 2)
+        self.assertEqual([r['count'] for r in res], [1, 3])
+
+    def test_filter_by_tag(self):
+        res = todo.query({'tags': ['chore']}, self._rows())
+        self.assertEqual(len(res), 2)
+
+    def test_filter_important(self):
+        res = todo.query({'important': True}, self._rows())
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]['count'], 1)
+
+    def test_combined(self):
+        res = todo.query({'tasklists': ['work'], 'due': True}, self._rows())
+        self.assertEqual([r['count'] for r in res], [1, 3])
+
+
+class TestSetconf(unittest.TestCase):
+    def test_creates_section_and_sets(self):
+        conf = configparser.ConfigParser()
+        todo._setconf(conf, 'general', 'dir', '/tmp/x')
+        self.assertEqual(conf.get('general', 'dir'), '/tmp/x')
+
+    def test_overwrites_existing(self):
+        conf = configparser.ConfigParser()
+        todo._setconf(conf, 'general', 'dir', '/a')
+        todo._setconf(conf, 'general', 'dir', '/b')
+        self.assertEqual(conf.get('general', 'dir'), '/b')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/todo.py
+++ b/todo.py
@@ -938,27 +938,32 @@ fn = {
     'details': display_detailed
 }
 
-# parse commands passed as arguments
-m = pat_cmds.findall(args)
+def _main():
+    # parse commands passed as arguments
+    m = pat_cmds.findall(args)
 
-if m:
-    #execute commands
-    for cmd in m:
-        c = pat_sepcmd.search(cmd.strip())
-        if c:
-            dashes = c.group(1)
-            command = c.group(2)
-            value = c.group(3)
+    if m:
+        #execute commands
+        for cmd in m:
+            c = pat_sepcmd.search(cmd.strip())
+            if c:
+                dashes = c.group(1)
+                command = c.group(2)
+                value = c.group(3)
 
-            if len(dashes) == 1:
-                for cm in command:
-                    _execute(cm, value)
-            else:
-                _execute(command, value)
+                if len(dashes) == 1:
+                    for cm in command:
+                        _execute(cm, value)
+                else:
+                    _execute(command, value)
 
-else:
-    #add new todo
-    if args.strip() == '':
-       display()
     else:
-        new(args)
+        #add new todo
+        if args.strip() == '':
+           display()
+        else:
+            new(args)
+
+
+if __name__ == '__main__':
+    _main()


### PR DESCRIPTION
Closes #6

Done. Two subtasks committed.

**What + why:**

1. **`subtask: guard CLI execution under __main__`** — todo.py ran its arg-parsing/command-dispatch block at import time, so `import todo` in a test would execute CLI commands off pytest's argv. Wrapped that block in `_main()` behind `if __name__ == '__main__':`. Root-cause enabler for testing; standard idiom, no behavior change to the CLI.

2. **`subtask: add unittest suite`** — `tests/test_todo.py`, stdlib `unittest`, no new deps. Points `HOME` at a temp dir with a seeded `config.cfg` before import so the interactive first-run setup never fires. Covers the pure logic: `_deltatime`, `_csvlist`, `_csvint`/`_csvfloat`, `_isImportant`, `_isDue`, `parseQuery`, `query`, `_setconf`.

Run: `python3 -m unittest discover -s tests`

**Caveat:** could not execute the suite — Python invocation needs interactive approval, unavailable in this run. Traced every assertion against the source by hand; all consistent. Recommend @stamat run the command above (or CI) to confirm green.

Skipped: tests for file-mutating funcs (`new`/`delete`/`_set`/`_get`) and CLI black-box — bigger fixtures, add when those paths need coverage.