### PR TITLE
overseer: Update the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,29 @@
 * **Task lists and tags** - task can have one task list and many tags
 * **Simple and complex views**
 
+### Requirements
+
+* **Python 3.9+** (tested on 3.9, 3.11 and 3.13)
+* No third-party packages needed — `todo` uses only the standard library and bundles its own copy of `texttable` in `lib/`
+
+Works on **Linux** and **Mac OS X**. The tool itself runs on Windows, but the installer does not (it relies on symlinks and `sudo`).
+
 ### Installation
-
-Requires **Python 2.6**
-
-Works on **Linux** and **Mac OS X**, should work on Windows too, except the install
 
 0. Download https://github.com/stamat/todo/archive/master.zip
   * `wget https://github.com/stamat/todo/archive/master.zip`
 0. Extract and `cd` to the extracted directory
-  * `unzip mater.zip && cd todo-master`
+  * `unzip master.zip && cd todo-master`
 0. `sudo ./install.py` - installs to *~/.todo* and creates a symlink */usr/local/bin/todo*
 0. `todo`
+
+#### One-liner (curl)
+
+If you trust the source, you can fetch and install in one go:
+
+```sh
+curl -L https://github.com/stamat/todo/archive/master.tar.gz | tar xz && cd todo-master && sudo ./install.py
+```
 
 Running `todo` will prompt you to enter the location for task CSV files to be saved. Personal recommendation would be your *dropbox* folder. This can be changed by editing a configuration file `~/.todo/config.cfg`
 


### PR DESCRIPTION
Closes #9

Done. One doc commit covers all asks.

**Changes to README.md:**
- **Requirements** (new section): Python 2.6 → **Python 3.9+** (matches CI matrix 3.9/3.11/3.13). Noted zero third-party deps — stdlib only, `texttable` bundled in `lib/`. Clarified Windows: tool runs, installer doesn't.
- **Installation**: fixed typo `mater.zip` → `master.zip`. Install steps (`sudo ./install.py`) unchanged — still correct.
- **Curl one-liner** (new): `curl -L .../master.tar.gz | tar xz && cd todo-master && sudo ./install.py`, gated with "if you trust the source".

Verified against code: `todo.py` imports stdlib + optional bundled `texttable` (`lib/texttable.py`), CI runs `unittest` on 3.9/3.11/3.13, `install.py` unchanged behavior.

Tests: docs-only change, no code touched — suite unaffected. Local run blocked by sandbox perms; CI will run on push.

Left alone (out of scope, not requested): dead cover-image link, pre-existing usage-text typos.

Not pushing — orchestrator's job.