### PR TITLE
overseer: Review the code

### DIFF
--- a/install.py
+++ b/install.py
@@ -27,18 +27,18 @@ if sudo_uid:
    user_uid = user.pw_uid
    user_gid = user.pw_gid
    
-def rchmod(path, mod, uid=None, gid=None):
+def rchmod(path, dir_mode, file_mode, uid=None, gid=None):
    for root, dirs, files in os.walk(path):
-      def setPriv(root, f):
-         path = os.path.join(root, f)
+      def setPriv(root, f, mode):
+         p = os.path.join(root, f)
          if uid is not None and gid is not None:
-            os.chown(path, uid, gid)
-         os.chmod(path, mod)
-      
-      for f in dirs:  
-         setPriv(root, f)
+            os.chown(p, uid, gid)
+         os.chmod(p, mode)
+
+      for f in dirs:
+         setPriv(root, f, dir_mode)
       for f in files:
-         setPriv(root, f)
+         setPriv(root, f, file_mode)
 
 if os.name == 'nt':
     print('Sorry, installation is currently not supported on Windows :\'(')
@@ -51,7 +51,7 @@ lib_path = os.path.join(config_path, 'lib')
 symln_path = '/usr/local/bin/todo'
 
 if not os.path.exists(config_path):
-   os.mkdir(config_path, 0o777)
+   os.mkdir(config_path, 0o755)
    os.chown(config_path, user_uid, user_gid)
 
 #get the version from file todo.py
@@ -63,7 +63,7 @@ shutil.copy('todo.py', config_path)
 if os.path.exists(lib_path):
    shutil.rmtree(lib_path)
 shutil.copytree('lib', lib_path)
-rchmod(config_path, 0o777, user_uid, user_gid)
+rchmod(config_path, 0o755, 0o644, user_uid, user_gid)
 
 try:
    os.symlink(new_exec_path, symln_path)

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -8,12 +8,17 @@ point HOME at a throwaway dir with a pre-seeded config BEFORE importing it.
 '''
 
 import os
+import io
 import sys
+import csv
+import contextlib
 import tempfile
 import configparser
 import unittest
 
-# --- make todo.py importable without triggering the interactive first-run setup
+# todo.py now runs its config/first-run side effects inside _init() (called from
+# _main()), so the module imports cleanly. HOME is still pointed at a throwaway
+# dir so nothing can touch a real ~/.todo if _init() ever runs.
 _TMP = tempfile.mkdtemp(prefix='todo_test_')
 os.environ['HOME'] = _TMP
 os.makedirs(os.path.join(_TMP, '.todo'), exist_ok=True)
@@ -26,6 +31,26 @@ sys.argv = ['todo.py']  # empty command line; execution is guarded by __main__ a
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import todo  # noqa: E402
+
+
+def _seed_csv(rows):
+    '''Write rows to a fresh todo.csv and point todo's globals at it.'''
+    d = tempfile.mkdtemp(prefix='todo_io_')
+    path = os.path.join(d, 'todo.csv')
+    with open(path, 'w', newline='') as f:
+        w = csv.DictWriter(f, fieldnames=todo.fieldnames)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    todo.destination_dir = d
+    todo.filename = path
+    todo.tmp_filename = os.path.join(d, 'tmp_todo.csv')
+    return path
+
+
+def _read_csv():
+    with open(todo.filename, newline='') as f:
+        return list(csv.DictReader(f))
 
 
 class TestDeltatime(unittest.TestCase):
@@ -155,6 +180,75 @@ class TestSetconf(unittest.TestCase):
         todo._setconf(conf, 'general', 'dir', '/a')
         todo._setconf(conf, 'general', 'dir', '/b')
         self.assertEqual(conf.get('general', 'dir'), '/b')
+
+
+class TestDetailsRegression(unittest.TestCase):
+    '''--details used int(row['due']); 'soon'/'later'/'' raised ValueError.'''
+    def test_details_survives_non_int_status(self):
+        _seed_csv([
+            {'task': 'a', 'important': '', 'due': 'soon',
+             'tasklist': 'work', 'tags': "['x']", 'time_spent': '90'},
+            {'task': 'b', 'important': '1', 'due': 'later',
+             'tasklist': '', 'tags': '', 'time_spent': ''},
+        ])
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            todo.display_detailed()  # must not raise
+        out = buf.getvalue()
+        self.assertIn('a', out)
+        self.assertIn('b', out)
+
+
+class TestParsenum(unittest.TestCase):
+    def setUp(self):
+        _seed_csv([{'task': 't1'}, {'task': 't2'}, {'task': 't3'}])
+
+    def test_valid(self):
+        self.assertEqual(todo._parsenum('2'), [2])
+
+    def test_last(self):
+        self.assertEqual(todo._parsenum('last'), [3])
+
+    def test_mod(self):
+        self.assertEqual(todo._parsenum('2', -1), [1])
+
+    def test_skips_garbage(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            self.assertEqual(todo._parsenum('1,abc,3'), [1, 3])
+        self.assertIn('invalid task id', buf.getvalue())
+
+    def test_all_garbage_returns_empty(self):
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(todo._parsenum('nope'), [])
+
+
+class TestGetSet(unittest.TestCase):
+    def test_roundtrip(self):
+        _seed_csv([{'task': 'old'}, {'task': 'two'}])
+        todo._set([0], 'task', 'new', False)  # 0-based list, like _parsenum(x, -1)
+        self.assertEqual(todo._get(1, 'task'), 'new')
+        self.assertEqual(todo._get(2, 'task'), 'two')
+
+
+class TestDelete(unittest.TestCase):
+    def test_delete_middle(self):
+        _seed_csv([{'task': 'a'}, {'task': 'b'}, {'task': 'c'}])
+        with contextlib.redirect_stdout(io.StringIO()):
+            todo.delete('2')
+        self.assertEqual([r['task'] for r in _read_csv()], ['a', 'c'])
+
+
+class TestNew(unittest.TestCase):
+    def test_parses_tasklist_and_tags(self):
+        _seed_csv([])  # header only
+        with contextlib.redirect_stdout(io.StringIO()):
+            todo.new('buy milk @home +urgent')
+        rows = _read_csv()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['task'], 'buy milk')
+        self.assertEqual(rows[0]['tasklist'], 'home')
+        self.assertEqual(todo._csvlist(rows[0]['tags']), ['urgent'])
 
 
 if __name__ == '__main__':

--- a/todo.py
+++ b/todo.py
@@ -178,14 +178,20 @@ def _parsenum(num, mod=None):
             reader = list(reader)
             last = len(reader)
 
-    for i in range(len(num)):
-        if num[i] == 'last':
-            num[i] = last
-        num[i] = int(num[i])
+    result = []
+    for token in num:
+        if token == 'last':
+            token = last
+        try:
+            n = int(token)
+        except (ValueError, TypeError):
+            _err(f'invalid task id "{token}", expected a number', 'invalid argument')
+            continue
         if mod:
-            num[i] += mod
+            n += mod
+        result.append(n)
 
-    return num
+    return result
 
 
 # Sets a value to a CSV file

--- a/todo.py
+++ b/todo.py
@@ -413,8 +413,8 @@ def _print(num, row, details=False):
             tags = ', '.join(tags)
         else:
             tags = ''
-        time = _deltatime(row['time_spent'])
-        details.add_row([num, row['task'], 'o' if int(row['important']) else '', 'o' if int(row['due']) else '', row['tasklist'], tags, time])
+        spent = _deltatime(row['time_spent'])
+        details.add_row([num, row['task'], 'o' if _isImportant(row['important']) else '', 'o' if _isDue(row['due']) else '', row['tasklist'], tags, spent])
 
 
 def parseQuery(s):

--- a/todo.py
+++ b/todo.py
@@ -581,7 +581,7 @@ def delete(num):
 
 # on completion a task is moved to the other file todo_complete.csv where it's stored for later mining
 def complete(arg):
-    pass
+    _err('completing tasks is not implemented yet', 'not implemented')
 
 #task time tracking
 def track(num):
@@ -817,7 +817,7 @@ def edit(args):
 
 def show(args):
     #shows a single task with all the details
-    pass
+    _err('showing a single task is not implemented yet', 'not implemented')
 
 # adds a new task
 def new(args):

--- a/todo.py
+++ b/todo.py
@@ -107,17 +107,23 @@ def _UTC2LocalTimestamp(utc_timestamp):
     return utc_timestamp
 
 
-conf = _readconf(config_cfg)
+# Reads config (running the interactive first-run setup if needed), resolves the
+# data-file paths and makes sure the todo file exists. Kept out of import time so
+# the module can be imported (e.g. by the test suite) without side effects.
+def _init():
+    global conf, destination_dir
+    global filename, tmp_filename, filename_completed, tmp_filename_completed
 
+    conf = _readconf(config_cfg)
 
-# FIRST INIT
-if not os.path.exists(config_path):
-    os.mkdir(config_path)
+    # FIRST INIT
+    if not os.path.exists(config_path):
+        os.mkdir(config_path)
 
-if not os.path.exists(config_cfg):
-    uname = os.path.split(user_path) #XXX: Will this always work?
-    uname = uname[-1]
-    print(f'''
+    if not os.path.exists(config_cfg):
+        uname = os.path.split(user_path) #XXX: Will this always work?
+        uname = uname[-1]
+        print(f'''
 TODO v{version}
 the simple CLI task manager with time tracking
 ----------------------------------------------
@@ -128,13 +134,13 @@ It looks like it\'s your first time using this application!?
 If you wish you can enter a directory where you would like to save the CSV todo data files. Saving them to Dropbox folder can be a good idea to backup them and access them across the devices.
 ''')
 
-    npath = _bother(config_path)
+        npath = _bother(config_path)
 
-    _setconf(conf, 'general', 'dir', npath)
-    _setconf(conf, 'general', 'name', uname.capitalize())
-    _writeconf(config_cfg, conf)
+        _setconf(conf, 'general', 'dir', npath)
+        _setconf(conf, 'general', 'name', uname.capitalize())
+        _writeconf(config_cfg, conf)
 
-    print('''
+        print('''
 Thanks, you're a real pal!
 
 
@@ -145,17 +151,17 @@ Thanks, you're a real pal!
             `Y'
 ''')
 
-destination_dir = conf.get('general', 'dir')
-filename = os.path.join(destination_dir, filename)
-tmp_filename = os.path.join(destination_dir, tmp_filename)
-filename_completed = os.path.join(destination_dir, filename_completed)
-tmp_filename_completed = os.path.join(destination_dir, tmp_filename_completed)
+    destination_dir = conf.get('general', 'dir')
+    filename = os.path.join(destination_dir, filename)
+    tmp_filename = os.path.join(destination_dir, tmp_filename)
+    filename_completed = os.path.join(destination_dir, filename_completed)
+    tmp_filename_completed = os.path.join(destination_dir, tmp_filename_completed)
 
-# create the todo file if it doesn't exists
-if not os.path.exists(filename):
-    with open(filename, 'w', newline='') as csv_out:
-        writer = csv.DictWriter(csv_out, fieldnames=fieldnames)
-        writer.writeheader()
+    # create the todo file if it doesn't exists
+    if not os.path.exists(filename):
+        with open(filename, 'w', newline='') as csv_out:
+            writer = csv.DictWriter(csv_out, fieldnames=fieldnames)
+            writer.writeheader()
 
 
 # updated print, used when outputing spent time on a task
@@ -942,6 +948,8 @@ fn = {
 }
 
 def _main():
+    _init()
+
     # parse commands passed as arguments
     m = pat_cmds.findall(args)
 

--- a/todo.py
+++ b/todo.py
@@ -97,10 +97,14 @@ def _writeconf(file_path, conf):
     return True
 
 def _UTCTimestamp():
-    return int( time.mktime(time.gmtime()) )
+    # time.time() is already seconds since the epoch (UTC); the old
+    # mktime(gmtime()) form double-applied the local offset.
+    return int(time.time())
 
 def _UTC2LocalTimestamp(utc_timestamp):
-    return utc_timestamp + (int(time.time()) - _UTCTimestamp())
+    # date/datetime.fromtimestamp() already converts an epoch value to local
+    # time, so no offset adjustment is needed here.
+    return utc_timestamp
 
 
 conf = _readconf(config_cfg)

--- a/todo.py
+++ b/todo.py
@@ -7,7 +7,7 @@
 
 import sys, os, re, time
 from datetime import datetime, date, timedelta
-import threading, atexit
+import threading
 import csv, configparser
 
 texttable_available = True
@@ -264,14 +264,7 @@ def _execute(command, args=None):
     else:
         print('Error: Unknown command',command)
 
-#TODO savetime if tracking a task time and you exit a terminal
-def _savetime():
-    global _TIME
-    if _TIME != 0:
-        _TIME = time.time() - _TIME
-        _set(num, 'time_spent', _TIME)
-
-#atexit.register(_savetime)
+#TODO: persist tracked time if the terminal exits mid-track (see track())
 
 
 def _deltatime(string):

--- a/todo.py
+++ b/todo.py
@@ -51,16 +51,16 @@ config_cfg = os.path.join(config_path, 'config.cfg')
 
 # Recursive ask to set the directory untill the the pathe xists
 def _bother(default):
-    npath = input(f'Enter directory to store data files (default={default}):').strip()
-    if npath == "":
-        print('As you command sir, we\'ll be using the default path')
-        return default
+    while True:
+        npath = input(f'Enter directory to store data files (default={default}):').strip()
+        if npath == "":
+            print('As you command sir, we\'ll be using the default path')
+            return default
 
-    if not (os.path.exists(npath) and os.path.isdir(npath)):
+        if os.path.exists(npath) and os.path.isdir(npath):
+            return npath
+
         print(f'Error: Sorry, the directory "{npath}" doesn\'t exist! Please try again.')
-        return _bother(default)
-
-    return npath
 
 # Reads an INI file and returns a ConfigParser object that can be iterated
 def _readconf(file_path):


### PR DESCRIPTION
Closes #8

Done. Solved review findings across 9 subtask commits on `overseer/issue-8`. Did NOT push — orchestrator pushes + opens PR.

## What changed

**Bugs (review #1, #3, #4, #5)**
- `1181fec` — `--details` crashed: `_print` did `int(row['due'])`, but `due` holds `'soon'`/`'later'`/`''`. Now uses `_isDue`/`_isImportant`. Also killed the `time`-module shadow.
- `82ed307` — timestamps: `_UTCTimestamp` used `time.mktime(time.gmtime())`, double-applying the local offset. Now `int(time.time())`; `_UTC2LocalTimestamp` is identity (`fromtimestamp` already localizes).
- `efb45a5` — `complete`/`show` were wired + documented but `pass`, looked like silent data loss. Now print a clear "not implemented".
- `0da9acc` — `_parsenum` crashed whole command on `todo -r abc`. Skips invalid ids with an error, processes the rest.

**Security (#11)**
- `1557471` — install created `~/.todo` + data/config `0o777` (world-writable). Now `0o755` dirs / `0o644` files; `rchmod` takes separate dir/file modes.

**Cleanup (#2, #12, #10)**
- `245e7bd` — removed dead `_savetime` (referenced undefined `num`) + unused `atexit`.
- `8fdcfdf` — `_bother` recursion → `while` loop.
- `b05d5fe` — moved config/first-run/file-create side effects out of import into `_init()` (called from `_main()`); module now imports cleanly.

**Tests**
- `92ecb47` — regression tests: `--details` on non-int status, `_parsenum` garbage-guard, `_get`/`_set`/`delete`/`new` IO roundtrips.

**Could not run tests** — Bash/python execution sandbox-blocked this session (same limit prior review hit). Verified via `py_compile`? also blocked. Traced every new test against the code paths by hand; CI (`unittest discover`, py 3.9/3.11/3.13) will exercise them on push.

One judgment call: "open a PR" needs a pushed branch, but instructions say don't push. Left both to the orchestrator.