### PR TITLE
overseer: Add a linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           python-version: '3.13'
       - run: pip install pylint
-      - run: pylint todo.py install.py tests
+      - run: pylint todo.py install.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pylint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - run: pip install pylint
+      - run: pylint todo.py install.py tests

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,33 @@
+[MAIN]
+# Vendored third-party code, not ours to lint.
+ignore-paths=^lib/.*$
+# Fail the build only if the score drops below this. Bump as code is cleaned up.
+fail-under=8.0
+
+[FORMAT]
+max-line-length=120
+
+[MESSAGES CONTROL]
+# Keep errors and genuinely useful warnings (unused-import/variable,
+# undefined-name, etc). Silence checks that fight this project's
+# deliberate style so pylint output stays signal, not noise.
+disable=
+    missing-module-docstring,
+    missing-class-docstring,
+    missing-function-docstring,
+    invalid-name,
+    global-statement,
+    global-variable-not-assigned,
+    redefined-outer-name,
+    redefined-builtin,
+    broad-exception-caught,
+    import-outside-toplevel,
+    unspecified-encoding,
+    fixme,
+    too-many-branches,
+    too-many-statements,
+    too-many-locals,
+    too-many-return-statements,
+    too-many-arguments,
+    too-many-nested-blocks,
+    too-few-public-methods

--- a/install.py
+++ b/install.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
-import sys, os, shutil, stat
+import sys
+import os
+import shutil
+import stat
 import pwd
 import errno
 

--- a/todo.py
+++ b/todo.py
@@ -5,10 +5,14 @@
     by Stamat <stamatmail@gmail.com>
 '''
 
-import sys, os, re, time
+import sys
+import os
+import re
+import time
 from datetime import datetime, date, timedelta
 import threading
-import csv, configparser
+import csv
+import configparser
 
 texttable_available = True
 try:


### PR DESCRIPTION
Closes #12

# Issue #12 — Add a linter (Pylint + CI)

Added Pylint config and a GitHub Actions lint job. Broke into 4 committed subtasks.

## What I did

1. **`subtask: split multi-module import lines onto one-per-line`**
   `import sys, os, re, time` (and the same in `install.py`) → one import per line.
   Fixes Pylint `multiple-imports` (C0410) at the source instead of muting it —
   cheap and it's the more conventional style anyway. Semantically identical.

2. **`subtask: add .pylintrc tuned to project style`**
   New `.pylintrc`:
   - `ignore-paths=^lib/.*$` — `lib/texttable.py` is vendored third-party, not ours to lint.
   - `max-line-length=120`.
   - `fail-under=8.0` — CI fails only if the score drops below 8.0. Bump as code is cleaned up.
   - `disable=` list silences checks that fight this project's deliberate style
     (missing docstrings, `invalid-name` for the mixedCase/`_Private` helpers,
     `global-statement`, `redefined-outer-name`, `redefined-builtin` (`help`),
     `broad-exception-caught`, `import-outside-toplevel` (the texttable try/except),
     `unspecified-encoding`, `fixme` (it's a TODO app, full of `#TODO`), and the
     `too-many-*` refactor nags).
   - **Kept enabled**: all errors, plus useful warnings like `unused-import`,
     `unused-variable`, `undefined-variable` — the bug-catching value.

3. **`subtask: add pylint CI workflow`** — `.github/workflows/lint.yml`, runs on
   push + PR, Python 3.13, `pip install pylint`, then `pylint`. Mirrors the
   existing `tests.yml` shape.

4. **`subtask: limit lint target to app code, exclude test harness`**
   Lint target is `todo.py install.py`. Dropped `tests/` — `test_todo.py` uses a
   `sys.path` shim + `import todo  # noqa` after code, which trips import-position
   checks that aren't worth chasing on a test file.

## Couldn't verify locally — please confirm on first CI run

The sandbox blocked installing/running Pylint (no network) and blocked running the
unittest suite (tests write to `~/.todo`). So:

- The **`fail-under=8.0`** threshold is an estimate. With the disable list above the
  score should sit comfortably above 8, but the **first CI run is the real check** —
  if it comes back red on score, adjust that one number in `.pylintrc`.
- My only code change was the cosmetic import split (subtask 1), which is
  semantically identical, so the existing test suite should be unaffected.

## Files
- `todo.py`, `install.py` — import split
- `.pylintrc` — new
- `.github/workflows/lint.yml` — new

`$1.51 · 43 turns · 1,582,710 in (1,542,070 cached) · 14,960 out`